### PR TITLE
Update bookmark store from bookmark api instead of client

### DIFF
--- a/src/lib/components/TextSelectionToolbar.svelte
+++ b/src/lib/components/TextSelectionToolbar.svelte
@@ -27,7 +27,6 @@ TODO:
         t,
         s,
         refs,
-        bookmarks,
         notes,
         highlights,
         selectedVerses,
@@ -105,14 +104,7 @@ TODO:
 
     async function modifyBookmark() {
         // If there is already a bookmark at this verse, remove it
-        const index = await findBookmark({
-            collection: $selectedVerses[0].collection,
-            book: $selectedVerses[0].book,
-            chapter: $selectedVerses[0].chapter,
-            verse: $selectedVerses[0].verse
-        });
-
-        if (index === -1) {
+        if (selectedVerseInBookmarks === -1) {
             await addBookmark({
                 collection: $selectedVerses[0].collection,
                 book: $selectedVerses[0].book,
@@ -122,10 +114,9 @@ TODO:
                 reference: selectedVerses.getReference(0)
             });
         } else {
-            await removeBookmark(index);
+            await removeBookmark(selectedVerseInBookmarks);
         }
 
-        await bookmarks.sync();
         selectedVerses.reset();
     }
 

--- a/src/lib/data/bookmarks.ts
+++ b/src/lib/data/bookmarks.ts
@@ -1,5 +1,6 @@
 import { openDB, type DBSchema } from "idb";
 import config from '$lib/data/config';
+import { bookmarks as bookmarksStore } from '$lib/data/stores/annotation';
 
 export interface BookmarkItem {
     date: number;
@@ -51,6 +52,7 @@ export async function addBookmark(item: {
         .books.findIndex((x) => x.id === item.book);
     const nextItem = {...item, date: date, bookIndex: bookIndex};
     await bookmarks.add("bookmarks", nextItem);
+    await bookmarksStore.sync();
 }
 
 export async function findBookmark(item: {
@@ -83,6 +85,7 @@ export async function findBookmarkByChapter(item: {
 export async function removeBookmark(date: number) {
     const bookmarks = await openBookmarks();
     await bookmarks.delete("bookmarks", date);
+    await bookmarksStore.sync();
 }
 
 export async function clearBookmarks() {


### PR DESCRIPTION
* call `bookmarks.sync()` from `addBookmark`/`removeBookmark` so that the bookmark API manages the store
* remove call to `findBookmark` from `modifyBookmark` since the key is already kept up-to-date in `selectedVerseInBookmark`