### PR TITLE
Fall back to download file when can't share

### DIFF
--- a/src/lib/data/annotation-share.ts
+++ b/src/lib/data/annotation-share.ts
@@ -1,32 +1,46 @@
 import config from '$lib/data/config';
 
-export async function shareAnnotation(annotation: any) {
+const SHARE_FILE_NAME = 'annotations.txt';
+
+function createShareFile(text: string) {
+    return new File([text], SHARE_FILE_NAME, { type: 'text/plain' });
+}
+
+async function shareText(title: string, text: string, file: File = undefined) {
     try {
-        await navigator.share({
-            title: config.name,
-            text: annotation.reference + '\n' + annotation.text
-        });
-        console.log('Successfully shared');
+        if (navigator.share) {
+            let shareData: ShareData = { title, text };
+            let files = [file];
+            if (file && navigator.canShare && navigator.canShare({ files })) {
+                shareData = { ...shareData, text: '', files };
+            }
+
+            await navigator.share(shareData);
+        } else {
+            const shareFile = file ? file : createShareFile(text);
+            const url = URL.createObjectURL(shareFile);
+
+            const anchor = document.createElement('a');
+            anchor.href = url;
+            anchor.download = SHARE_FILE_NAME;
+            anchor.click();
+
+            URL.revokeObjectURL(url);
+        }
     } catch (error) {
         console.error('Error sharing: ', error);
     }
 }
 
+export async function shareAnnotation(annotation: any) {
+    await shareText(config.name, annotation.reference + '\n' + annotation.text);
+}
+
 export async function shareAnnotations(annotations: any) {
-    let text = config.name;
-    annotations.forEach((item) => {
-        text += '\n\n' + item.reference + '\n' + item.text;
-    });
+    let text =
+        config.name +
+        '\n\n' +
+        annotations.map((item) => `${item.reference}\n${item.text}`).join('\n\n');
 
-    const file = new File([text], 'annotations.txt', { type: 'text/plain' });
-
-    try {
-        await navigator.share({
-            title: config.name,
-            files: [file]
-        });
-        console.log('Successfully shared');
-    } catch (error) {
-        console.error('Error sharing: ', error);
-    }
+    await shareText(config.name, text, createShareFile(text));
 }

--- a/src/routes/bookmarks/+page.svelte
+++ b/src/routes/bookmarks/+page.svelte
@@ -21,7 +21,7 @@
                 goto(`${base}/`);
                 break;
             case $t['Annotation_Menu_Share']:
-                shareAnnotation(bookmark);
+                await shareAnnotation(bookmark);
                 break;
             case $t['Annotation_Menu_Delete']:
                 await removeBookmark(bookmark.date);
@@ -61,7 +61,7 @@
                 <button
                     class="dy-btn dy-btn-ghost dy-btn-circle"
                     on:click={async () =>
-                        shareAnnotations(toSorted($page.data.bookmarks, sortOrder))}
+                        await shareAnnotations(toSorted($page.data.bookmarks, sortOrder))}
                 >
                     <ShareIcon color="white" />
                 </button>

--- a/src/routes/highlights/+page.svelte
+++ b/src/routes/highlights/+page.svelte
@@ -20,7 +20,7 @@
                 goto(`${base}/`);
                 break;
             case $t['Annotation_Menu_Share']:
-                shareAnnotation(highlight);
+                await shareAnnotation(highlight);
                 break;
             case $t['Annotation_Menu_Delete']:
                 await removeHighlight(highlight.date);
@@ -67,7 +67,7 @@
                 <button
                     class="dy-btn dy-btn-ghost dy-btn-circle"
                     on:click={async () =>
-                        shareAnnotations(toSorted($page.data.highlights, sortOrder))}
+                        await shareAnnotations(toSorted($page.data.highlights, sortOrder))}
                 >
                     <ShareIcon color="white" />
                 </button>

--- a/src/routes/notes/+page.svelte
+++ b/src/routes/notes/+page.svelte
@@ -24,7 +24,7 @@
                 console.log('Ready to edit: ', note.reference, ' ', note.text);
                 break;
             case $t['Annotation_Menu_Share']:
-                shareAnnotation(note);
+                await shareAnnotation(note);
                 break;
             case $t['Annotation_Menu_Delete']:
                 await removeNote(note.date);
@@ -63,7 +63,8 @@
             <div slot="right-buttons">
                 <button
                     class="dy-btn dy-btn-ghost dy-btn-circle"
-                    on:click={async () => shareAnnotations(toSorted($page.data.notes, sortOrder))}
+                    on:click={async () =>
+                        await shareAnnotations(toSorted($page.data.notes, sortOrder))}
                 >
                     <ShareIcon color="white" />
                 </button>


### PR DESCRIPTION
* Chrome only support sharing on ChromeOS and Windows
* Firefox only supports if feature is turned on and doesn't work
* Edge and Safari supports all platforms
* Refactor share functions so that they both fall back to download file